### PR TITLE
Fix biased randomness in dice roll

### DIFF
--- a/dice_app.c
+++ b/dice_app.c
@@ -5,6 +5,15 @@
 
 const Icon* draw_dice_frame;
 
+static uint16_t unbiased_rand (uint16_t max) {
+    uint16_t remainder = RAND_MAX % max;
+    uint16_t x;
+    do {
+        x = rand();
+    } while (x >= RAND_MAX - remainder);
+    return 1 + x % max;
+}
+
 static void update(State* const state) {
     if(state->app_state == SwipeLeftState) {
         for(uint8_t i = 0; i < DICE_TYPES; i++) {
@@ -67,7 +76,7 @@ static void roll(State* const state) {
 
     for(uint8_t i = 0; i < MAX_DICE_COUNT; i++) {
         if(i < state->dice_count) {
-            state->rolled_dices[i] = (rand() % dice_types[state->dice_index].type) + 1;
+            state->rolled_dices[i] = unbiased_rand(dice_types[state->dice_index].type);
             state->roll_result += state->rolled_dices[i];
         } else {
             state->rolled_dices[i] = 0;


### PR DESCRIPTION
RAND_MAX on flipper's arm-none-eabi is only 32767.
Using modulo will produce a biased result.

e.g. For a d20 roll, then numbers 1-8 are more likely: 
There are 1639 possiblities for each of the numbers 1-8,
but only 1638 possibilties to get a number of 9-20.